### PR TITLE
Change cloudfront import

### DIFF
--- a/utils/s3.py
+++ b/utils/s3.py
@@ -5,7 +5,7 @@ import json
 import re
 import os
 from botocore.exceptions import BotoCoreError
-from cloudfront import get_cloudfront_client
+from utils.cloudfront import get_cloudfront_client
 
 
 def get_s3_client(aws_account):


### PR DESCRIPTION
We found an issue while building docker compose . The problem was that it couldn't be find cloudfront module.

The solution was changing the way we import cloudfront in utils/s3 module.


