### PR TITLE
Add duration in MediaSerializer

### DIFF
--- a/api/serializers/media.py
+++ b/api/serializers/media.py
@@ -32,6 +32,7 @@ class MediaSerializer(serializers.ModelSerializer):
             'enable_ads',
             'autoplay',
             'created_at',
+            'duration',
             'media_type',
             'job_percent_complete',
             'has_thumbnail',
@@ -51,10 +52,13 @@ class MediaSerializer(serializers.ModelSerializer):
         _, media_url, _ = obj.get_urls()
         return media_url
 
+
 class CreateMediaSerializer(serializers.ModelSerializer):
     content_type = serializers.CharField(required=True)
     video_id = serializers.CharField(required=False)
-    channel_id = serializers.PrimaryKeyRelatedField(queryset=Channel.objects, required=False, default=None)
+    channel_id = serializers.PrimaryKeyRelatedField(
+        queryset=Channel.objects, required=False, default=None
+    )
 
     class Meta:
         model = Media
@@ -77,7 +81,9 @@ class CreateMediaSerializer(serializers.ModelSerializer):
 
             organization = user.organization
             if data not in organization.channels.all():
-                raise ValidationError('The channel does not belong to your organization.')
+                raise ValidationError(
+                    'The channel does not belong to your organization.'
+                )
 
         return data
 
@@ -100,8 +106,7 @@ class CreateMediaSerializer(serializers.ModelSerializer):
 class UpdateMediaSerializer(serializers.ModelSerializer):
     channel = serializers.PrimaryKeyRelatedField(queryset=Channel.objects)
     tags = serializers.ManyRelatedField(
-        required=False,
-        child_relation=serializers.CharField()
+        required=False, child_relation=serializers.CharField()
     )
 
     class Meta:
@@ -113,7 +118,7 @@ class UpdateMediaSerializer(serializers.ModelSerializer):
             'ads_vast_url',
             'enable_ads',
             'autoplay',
-            'has_thumbnail'
+            'has_thumbnail',
         )
 
     def validate(self, data):
@@ -131,8 +136,7 @@ class UpdateMediaSerializer(serializers.ModelSerializer):
                 for tag in tags_tmp:
                     try:
                         tag_object, created = Tag.objects.get_or_create(
-                            name=tag,
-                            organization=user.organization
+                            name=tag, organization=user.organization
                         )
                         tags_array.append(tag_object)
                     except MultipleObjectsReturned:
@@ -143,7 +147,9 @@ class UpdateMediaSerializer(serializers.ModelSerializer):
             channel = data.get('channel')
             organization = user.organization
             if channel not in organization.channels.all():
-                raise ValidationError('The channel does not belong to your organization.')
+                raise ValidationError(
+                    'The channel does not belong to your organization.'
+                )
         else:
             raise ValidationError('The video must belong to a channel.')
 
@@ -151,8 +157,9 @@ class UpdateMediaSerializer(serializers.ModelSerializer):
 
 
 class PartialUpdateMediaSerializer(UpdateMediaSerializer):
-    channel = serializers.PrimaryKeyRelatedField(required=False,
-                                                 queryset=Channel.objects)
+    channel = serializers.PrimaryKeyRelatedField(
+        required=False, queryset=Channel.objects
+    )
 
     def validate(self, data):
         request = self.context.get("request")
@@ -168,8 +175,7 @@ class PartialUpdateMediaSerializer(UpdateMediaSerializer):
                 for tag in tags_tmp:
                     try:
                         tag_object, created = Tag.objects.get_or_create(
-                            name=tag,
-                            organization=user.organization
+                            name=tag, organization=user.organization
                         )
                         tags_array.append(tag_object)
                     except MultipleObjectsReturned:
@@ -181,9 +187,11 @@ class PartialUpdateMediaSerializer(UpdateMediaSerializer):
             channel = data.get('channel')
             organization = user.organization
             if channel not in organization.channels.all():
-                raise ValidationError('The channel does not belong to your organization.')
+                raise ValidationError(
+                    'The channel does not belong to your organization.'
+                )
         return data
 
 
-class ThumbnailMediaSerializer (serializers.Serializer):
+class ThumbnailMediaSerializer(serializers.Serializer):
     content_type = serializers.CharField(required=True)


### PR DESCRIPTION
## Description:
There is already a way to know how long the videos are. 
Once the check_job_status method inside mediaconvert.py achieves the status COMPLETE, inside MediaConvert Output Details there is an attribute called DurationInMs that indicates the duration in ms for the job.
That value is stored in the media object inside the duration attribute as DurationInMs / 1000 so the video duration is stored in seconds.

The problem was that the GET method for the API returns a serialized version of the media model (not all the attributes), so the solution was to add to the MediaSerializer the 'duration' attribute.